### PR TITLE
Add Error Handling to DataBase Schema Updates

### DIFF
--- a/sd-utility.php
+++ b/sd-utility.php
@@ -1830,18 +1830,66 @@ function checkDatabase()
 
     if ($schemaVersion == "2")
     {
-        $dbhSD->exec("RENAME TABLE SDMessages TO messages");
-        $dbhSD->exec("RENAME TABLE SDcredits TO credits");
-        $dbhSD->exec("RENAME TABLE SDimageCache TO imageCache");
-        $dbhSD->exec("RENAME TABLE SDlineupCache TO lineups");
-        $dbhSD->exec("RENAME TABLE SDpeople TO people");
-        $dbhSD->exec("RENAME TABLE SDprogramCache TO programs");
-        $dbhSD->exec("RENAME TABLE SDprogramgenres TO programGenres");
-        $dbhSD->exec("RENAME TABLE SDprogramrating TO programRatings");
-        $dbhSD->exec("RENAME TABLE SDschedule TO schedules");
-        $dbhSD->exec("ALTER TABLE schedules ADD column date CHAR(10) NOT NULL");
-        $dbhSD->exec("ALTER TABLE schedules DROP KEY sid");
-        $dbhSD->exec("ALTER TABLE schedules ADD UNIQUE KEY station_date (stationID,date)");
+	try {
+        	$dbhSD->exec("RENAME TABLE SDMessages TO messages");
+	} catch (PDOException $ex) {
+		//do nothing
+	}
+	try {
+        	$dbhSD->exec("RENAME TABLE SDcredits TO credits");
+	} catch (PDOException $ex) {
+		//do nothing
+	}        
+	try {
+		$dbhSD->exec("RENAME TABLE SDimageCache TO imageCache");
+	} catch (PDOException $ex) {
+		//do nothing
+	}
+	try {
+        	$dbhSD->exec("RENAME TABLE SDlineupCache TO lineups");
+	} catch (PDOException $ex) {
+		//do nothing
+	}
+	try {
+        	$dbhSD->exec("RENAME TABLE SDpeople TO people");
+	} catch (PDOException $ex) {
+		//do nothing
+	}
+	try {
+        	$dbhSD->exec("RENAME TABLE SDprogramCache TO programs");
+	} catch (PDOException $ex) {
+		//do nothing
+	}
+	try {
+        	$dbhSD->exec("RENAME TABLE SDprogramgenres TO programGenres");
+	} catch (PDOException $ex) {
+		//do nothing
+	}
+	try {
+        	$dbhSD->exec("RENAME TABLE SDprogramrating TO programRatings");
+	} catch (PDOException $ex) {
+		//do nothing
+	}
+	try {
+        	$dbhSD->exec("RENAME TABLE SDschedule TO schedules");
+	} catch (PDOException $ex) {
+		//do nothing
+	}
+	try {
+        	$dbhSD->exec("ALTER TABLE schedules ADD column date CHAR(10) NOT NULL");
+	} catch (PDOException $ex) {
+		//do nothing
+	}
+	try {
+        	$dbhSD->exec("ALTER TABLE schedules DROP KEY sid");
+	} catch (PDOException $ex) {
+		//do nothing
+	}
+	try {
+        	$dbhSD->exec("ALTER TABLE schedules ADD UNIQUE KEY station_date (stationID,date)");
+	} catch (PDOException $ex) {
+		//do nothing
+	}
         settingSD("SchedulesDirectJSONschemaVersion", "3");
     }
 }

--- a/sd-utility.php
+++ b/sd-utility.php
@@ -1824,7 +1824,7 @@ function checkDatabase()
 
     if ($schemaVersion == "1")
     {
-        $dbhSD->exec("ALTER TABLE SDpeople ADD INDEX(name)");
+        $dbhSD->exec("ALTER TABLE people ADD INDEX(name)");
         settingSD("SchedulesDirectJSONschemaVersion", "2");
     }
 


### PR DESCRIPTION
@rkulagowski as promised...

Fixes #9 

Please review these changes. I am not a PHP programmer nor do I have a deep understanding of the SD JSON API. These changes include what worked for me in order to migrate from API-2014-05-30 to API-2014-12-01.

When first running the script I encountered an unhandled exception trying to alter the SDpeople table. The first commit references this.

After getting past that I started running into the same unhandled exception errors trying to update the schema to version 3. The second commit attempts to address that by wrapping the original code in try/catch blocks.

Note that the second commit has TODO items. As mentioned, I'm not well enough versed in this code to really know what to do in the catch blocks so they are presently no-ops. I think this is a step in the right direction because it adds the beginning of proper error handling.